### PR TITLE
Namespace fix

### DIFF
--- a/Block/Sales/Order/Email/Items/Order/DefaultOrder.php
+++ b/Block/Sales/Order/Email/Items/Order/DefaultOrder.php
@@ -13,7 +13,7 @@ use Magento\Sales\Model\Order\Item as OrderItem;
 /**
  * Class DefaultOrder
  *
- * @package Eadesigndev\Opicmsppdfgenerator\Block\Sales\Order\Email\Items\Order
+ * @package Eadesigndev\Pdfgenerator\Block\Sales\Order\Email\Items\Order
  */
 class DefaultOrder extends Template
 {

--- a/Block/Sales/Shipment/Items.php
+++ b/Block/Sales/Shipment/Items.php
@@ -17,10 +17,10 @@
  * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
-namespace Eadesigndev\Opicmsppdfgenerator\Block\Sales\Shipment;
+namespace Eadesigndev\Pdfgenerator\Block\Sales\Shipment;
 
-use Eadesigndev\Opicmsppdfgenerator\Helper\Data;
-use Eadesigndev\Opicmsppdfgenerator\Model\Source\TemplateType;
+use Eadesigndev\Pdfgenerator\Helper\Data;
+use Eadesigndev\Pdfgenerator\Model\Source\TemplateType;
 use Magento\Framework\Registry;
 use Magento\Framework\View\Element\Template\Context;
 
@@ -83,7 +83,7 @@ class Items extends \Magento\Shipping\Block\Items
      */
     public function getPrintPDFUrl($source)
     {
-        return $this->getUrl('opicmsppdfgenerator/index/index', [
+        return $this->getUrl('pdfgenerator/index/index', [
             'template_id' => $this->lastitem->getId(),
             'order_id' => $source->getOrder()->getId(),
             'source_id' => $source->getId()

--- a/Test/Unit/Helper/TestData.php
+++ b/Test/Unit/Helper/TestData.php
@@ -6,7 +6,7 @@
 
 namespace Eadesigndev\Pdfgenerator\Test\Unit\Helper;
 
-use Eadesigndev\Opicmsppdfgenerator\Helper\Data as DataHelper;
+use Eadesigndev\Pdfgenerator\Helper\Data as DataHelper;
 use Eadesigndev\Pdfgenerator\Model\ResourceModel\Pdfgenerator\CollectionFactory as PdfGeneratorCollectionFactory;
 use Eadesigndev\Pdfgenerator\Model\ResourceModel\Pdfgenerator\Collection as PdfGeneratorCollection;
 use Magento\Framework\App\Config\ScopeConfigInterface;


### PR DESCRIPTION
The extension is currently broken due to ambiguous namespace use for Eadesigndev\Pdfgenerator\Helper\Data (the namespace is actually called Eadesigndev\Pdfgenerator\Helper\Data, not Eadesigndev\Opicmsppdfgenerator\Helper\Data). Fixed by unifying namespace to Eadesigndev\Pdfgenerator instead of Eadesigdev\Opicmsppdfgenerator in the affected files.