### PR TITLE
Changed stores form element type to "multiselect"

### DIFF
--- a/view/adminhtml/ui_component/pdfgenerator_template_form.xml
+++ b/view/adminhtml/ui_component/pdfgenerator_template_form.xml
@@ -176,7 +176,7 @@
                 <item name="config" xsi:type="array">
                     <item name="dataType" xsi:type="string">int</item>
                     <item name="label" xsi:type="string" translate="true">Store View</item>
-                    <item name="formElement" xsi:type="string">select</item>
+                    <item name="formElement" xsi:type="string">multiselect</item>
                     <item name="source" xsi:type="string">template</item>
                     <item name="dataScope" xsi:type="string">store_id</item>
                     <item name="default" xsi:type="string">0</item>


### PR DESCRIPTION
The module already handles "1 template to many stores" relation, so we can safely change input type from "select" to "multiselect".