### PR TITLE
Bugfix for empty email and 500 Error when placing an order

### DIFF
--- a/Model/Email/Message.php
+++ b/Model/Email/Message.php
@@ -4,6 +4,7 @@ namespace Eadesigndev\Pdfgenerator\Model\Email;
 
 use Magento\Framework\Mail\MailMessageInterface;
 use Zend\Mime\Mime;
+use Zend\Mime\Part;
 use Zend\Mime\PartFactory;
 use Zend\Mail\MessageFactory as MailFactory;
 use Zend\Mime\MessageFactory as MimeFactory;
@@ -152,7 +153,8 @@ class Message extends \Magento\Framework\Mail\Message implements MailMessageInte
 
     private function createHtmlMimeFromString($htmlBody)
     {
-        $htmlPart = $this->partFactory->create([$htmlBody]);
+        // $htmlPart = $this->partFactory->create([$htmlBody]);
+        $htmlPart = new Part($htmlBody);
         $htmlPart->setCharset($this->zendMessage->getEncoding());
         $htmlPart->setType(Mime::TYPE_HTML);
         $mimeMessage = $this->mimeMessageFactory->create();

--- a/Model/Email/Message.php
+++ b/Model/Email/Message.php
@@ -101,9 +101,9 @@ class Message extends \Magento\Framework\Mail\Message implements MailMessageInte
     /**
      * {@inheritdoc}
      */
-    public function setFrom($fromAddress)
+    public function setFromAddress($fromAddress, $fromName = null)
     {
-        $this->zendMessage->setFrom($fromAddress);
+        $this->zendMessage->setFrom($fromAddress, $fromName);
         return $this;
     }
 
@@ -153,7 +153,6 @@ class Message extends \Magento\Framework\Mail\Message implements MailMessageInte
 
     private function createHtmlMimeFromString($htmlBody)
     {
-        // $htmlPart = $this->partFactory->create([$htmlBody]);
         $htmlPart = new Part($htmlBody);
         $htmlPart->setCharset($this->zendMessage->getEncoding());
         $htmlPart->setType(Mime::TYPE_HTML);


### PR DESCRIPTION
first commit:

`Model\Email\Message` overrides the private method `createHtmlMimeFromString` of the parent class and uses `Zend\Mime\PartFactory` to create a Part instead of using `new Zend\Mime\Part()` like the parent class. This results in empty emails

second commit:

`Magento\Framework\Mail\Message::setFrom` is deprecated since `102.0.1`. The `setFromAddress` method should be used instead, as stated in the documentation. However calling the parent method directly will result in an error because `$this->zendMessage` will be undefined. It is set in the constructor of the class, but that is never called and instead the constructor of the child class is called. This error is thrown when a customer tries to place an order.
